### PR TITLE
Add the option to specify a custom seperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ bower install --save human-format
 
 ```javascript
 humanFormat(1337)
-//=> '1.34k'
+//=> '1.34 k'
 
 // The number of decimals can be changed.
 humanFormat(1337, {
   decimals: 1
 })
-//=> '1.3k'
+//=> '1.3 k'
 
 // Units and scales can be specified.
 humanFormat(65536, {
@@ -43,6 +43,12 @@ humanFormat(65536, {
 	unit: 'B'
 })
 //=> 64 kiB
+
+// A custom seperator can be specified.
+humanFormat(1337, {
+  seperator: ' - '
+})
+//=> 1.34 - k
 
 // Custom scales can be created!
 var timeScale = new humanFormat.Scale({

--- a/index.js
+++ b/index.js
@@ -229,7 +229,10 @@
     unit: '',
 
     // Decimal digits for formatting.
-    decimals: 2
+    decimals: 2,
+
+    // Seperator to use between value and units
+    seperator: ' '
   }
 
   function humanFormat (value, opts) {
@@ -237,7 +240,7 @@
 
     var info = humanFormat$raw(value, opts)
     var suffix = info.prefix + opts.unit
-    return round(info.value, opts.decimals) + (suffix ? ' ' + suffix : '')
+    return round(info.value, opts.decimals) + (suffix ? opts.seperator + suffix : '')
   }
 
   function humanFormat$parse (str, opts) {

--- a/index.spec.js
+++ b/index.spec.js
@@ -60,6 +60,10 @@ describe('humanFormat()', function () {
     expect(humanFormat(0, { unit: 'g' })).to.equal('0 g')
   })
 
+  it('can use custom seperators', function () {
+    expect(humanFormat(1337, {seperator: ' - '})).to.equal('1.34 - k')
+  })
+
   it('can use custom scale', function () {
     var scale = humanFormat.Scale.create(
       ',ki,Mi,Gi'.split(','),


### PR DESCRIPTION
This PR adds the option to specify a custom separator between the rounded value and units. This is helpful to me as I do not want a space between my value and units (i.e. '1.34k' instead of '1.34 k').

Comes with tests, README updates. Let me know if there's anything missing and I'll add it!