### PR TITLE
should be "1" instead of "0" for seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ humanFormat(1337, {
 
 // Custom scales can be created!
 var timeScale = new humanFormat.Scale({
-	seconds: 0,
+	seconds: 1,
 	minutes: 60,
 	hours: 3600,
 	days: 86400,


### PR DESCRIPTION
The example shown will give "infinity" for times < 60 seconds (divide by
0 error).  The seconds divisor should be "1" instead of "0"